### PR TITLE
fix(docker): resolve build failure caused by distutils deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:stable-slim
-
+FROM debian:bookworm-slim
 # Set environment variables
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -23,7 +22,7 @@ RUN apt-get -y install python3-minimal python3-pypandoc
 RUN apt-get -y install pipenv
 RUN apt-get -y install wget
 RUN apt-get -y install libpangocairo-1.0-0
-RUN apt-get -y install python3-distutils
+RUN apt-get -y install python3-setuptools
 RUN apt -y purge python3-gunicorn gunicorn
 
 ARG TARGETARCH


### PR DESCRIPTION
I fixed the build issue caused by some changes in the Debian 12 package repositories, which dropped python3-distutils to comply with PEP 632 and modern Python packaging standards.

- Pinned base image to `debian:bookworm-slim` for deterministic builds.
- Replaced deprecated `python3-distutils` with `python3-setuptools` to fix exit code 100 on apt-get install.

Tested the changes, and it builds without any error now.